### PR TITLE
Updated README. Only checked Amazon Lightsail

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,17 +158,17 @@ sudo apt-get install -y apt-transport-https ca-certificates
 sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 echo "deb https://apt.dockerproject.org/repo ubuntu-xenial main" | sudo tee /etc/apt/sources.list.d/docker.list
 sudo apt-get update
-sudo apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
+sudo apt-get install -y linux-image-extra-virtual
 sudo apt-get install -y docker-engine
 sudo service docker start
 
-sudo docker pull tcool/cl-base
+sudo docker pull tcool/cl-alpine
 ```
 
 完了後、WebコンソールからSSH接続をして、次のコマンドを打てば、コンテナの中に入れます。
 
 ```bash
-docker run -it -p 8888:8888 --name k-mokumoku tcool/cl-base
+docker run -it -p 8888:8888 --name k-mokumoku tcool/cl-alpine
 ```
 
 ### 謝辞


### PR DESCRIPTION
Do tcool/cl-base and tcool/cl-web exist?
[On tcool docker hub](https://hub.docker.com/u/tcool/)  I can't find them

For 
```sudo apt-get install -y linux-image-extra-virtual```
Without ```linux-image-extra-$(uname -r)``` I still succeed